### PR TITLE
fix text limit

### DIFF
--- a/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a minor change to the `Message` class in the `Application/src/RazorPagesTestSample/Data/Message.cs` file. The change increases the character limit for messages from 200 to 250 characters.